### PR TITLE
Improve dockerfile

### DIFF
--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -1,5 +1,4 @@
 FROM python:2.7
-ARG password
 
 # install dependenices
 RUN apt-get update && apt-get upgrade -y && \
@@ -14,6 +13,4 @@ COPY manage.py ./
 COPY setup.py ./
 COPY ./mittab ./mittab
 
-RUN python manage.py migrate
 RUN python manage.py collectstatic --noinput
-RUN python manage.py initialize_tourney --tab-password "$password" tournament .


### PR DESCRIPTION
We shouldn't be running `initialize_tourney` and `migrate` from the dockerfile