### PR TITLE
Integrate sentry.io for error monitoring

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+SENTRY_DSN=FakeKey

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,9 @@ services:
       - ./:/var/www/tab
     links:
       - memcached:memcached
-    env_file: .env
+    env_file:
+      - .env
+      - .env.secret
     command: /usr/local/bin/gunicorn mittab.wsgi:application -w 2 -b :8000 -t 300
 
   nginx:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - ./:/var/www/tab
     links:
       - memcached:memcached
+    env_file: .env
     command: /usr/local/bin/gunicorn mittab.wsgi:application -w 2 -b :8000 -t 300
 
   nginx:

--- a/mittab/settings.py
+++ b/mittab/settings.py
@@ -42,6 +42,7 @@ INSTALLED_APPS = (
     'django.contrib.staticfiles',
     'south',
     'mittab.apps.tab',
+    'raven.contrib.django.raven_compat',
 )
 
 MIDDLEWARE_CLASSES = (
@@ -69,6 +70,12 @@ DATABASES = {
         'NAME': os.path.join(BASE_DIR, 'mittab', 'pairing_db.sqlite3'),
         'ATOMIC_REQUESTS': True,
     }
+}
+
+# Error monitoring
+# https://docs.sentry.io/clients/python/integrations/django/
+RAVEN_CONFIG = {
+    'dsn': os.environ.get('SENTRY_DSN')
 }
 
 # Internationalization

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ django-localflavor==1.0
 gunicorn==19.7.1
 xlrd==0.9.4
 xlwt==1.0.0
+raven==6.1.0


### PR DESCRIPTION
adresses https://github.com/jolynch/mit-tab/issues/67

Depends on this PR being merged: https://github.com/BenMusch/mittab-deploy/pull/24 so that the environment variable can be set