### PR TITLE
Remove delete buttons

### DIFF
--- a/mittab/apps/tab/debater_views.py
+++ b/mittab/apps/tab/debater_views.py
@@ -46,7 +46,7 @@ def view_debater(request, debater_id):
         form = DebaterForm(instance=debater)
         # Really only should be one, TODO: change to get when we have tests
         teams = Team.objects.filter(debaters = debater)
-        links = [('/debater/'+str(debater_id)+'/delete/', 'Delete', True)]
+        links = []
         for team in teams:
             links.append(('/team/'+str(team.id)+'/', "View %s"%team.name, False))
 

--- a/mittab/apps/tab/judge_views.py
+++ b/mittab/apps/tab/judge_views.py
@@ -88,14 +88,13 @@ def view_judge(request, judge_id):
         base_url = '/judge/'+str(judge_id)+'/'
         scratch_url = base_url + 'scratches/view/'
         delete_url =  base_url + 'delete/'
-        links = [(scratch_url,'Scratches for '+str(judge.name),False),
-                 (delete_url,'Delete', True)]
+        links = [(scratch_url,'Scratches for '+str(judge.name),False)]
         return render_to_response('data_entry.html', 
                                  {'form': form,
                                   'links': links,
                                   'title': "Viewing Judge: %s" %(judge.name)}, 
                                   context_instance=RequestContext(request))
-    
+
 def enter_judge(request):
     if request.method == 'POST':
         form = JudgeForm(request.POST)

--- a/mittab/apps/tab/team_views.py
+++ b/mittab/apps/tab/team_views.py
@@ -66,8 +66,7 @@ def view_team(request, team_id):
                                       context_instance=RequestContext(request))
     else:
         form = TeamForm(instance=team)
-        links = [('/team/'+str(team_id)+'/scratches/view/','Scratches for '+str(team.name), False),
-                 ('/team/'+str(team_id)+'/delete/', 'Delete', True)]
+        links = [('/team/'+str(team_id)+'/scratches/view/','Scratches for '+str(team.name), False)]
         for deb in team.debaters.all():
             links.append(('/debater/'+str(deb.id)+'/', "View %s" % deb.name, False))
         return render_to_response('data_entry.html', 

--- a/mittab/apps/tab/views.py
+++ b/mittab/apps/tab/views.py
@@ -200,10 +200,9 @@ def view_room(request, room_id):
                                       context_instance=RequestContext(request))
     else:
         form = RoomForm(instance=room)
-        links = [('/room/'+str(room_id)+'/delete/', 'Delete', True)]
         return render_to_response('data_entry.html', 
                                  {'form': form,
-                                  'links': links,
+                                  'links': [],
                                   'title': "Viewing Room: %s"%(room.name)}, 
                                  context_instance=RequestContext(request))
 


### PR DESCRIPTION
Deleting a team/room/debater/judge can destroy results. The "Delete" button is much clearer than the "check out" option so people may click it without thinking. Let's prevent people from making a choice with unclear (but very bad) implications