### PR TITLE
Backup before judge assignments + don't return a form after assigning judges

### DIFF
--- a/mittab/apps/tab/pairing_views.py
+++ b/mittab/apps/tab/pairing_views.py
@@ -158,8 +158,6 @@ def pair_round(request):
 def assign_judges_to_pairing(request):
     current_round_number = TabSettings.objects.get(key="cur_round").value - 1
     if request.method == 'POST':
-        print "Assigning judges"
-        print request.POST
         panel_points, errors = [], []
         potential_panel_points = [k for k in request.POST.keys() if k.startswith('panel_')]
         for point in potential_panel_points:
@@ -184,9 +182,7 @@ def assign_judges_to_pairing(request):
                                       'error_name': "",
                                       'error_info': str(e)},
                                       context_instance=RequestContext(request))
-        return view_round(request, current_round_number)
-    else:
-        return view_round(request, current_round_number)
+    return redirect('/pairings/status/')
 
 
 @permission_required('tab.tab_settings.can_change', login_url='/403/')

--- a/mittab/apps/tab/pairing_views.py
+++ b/mittab/apps/tab/pairing_views.py
@@ -176,6 +176,7 @@ def assign_judges_to_pairing(request):
         rounds = list(Round.objects.filter(round_number=current_round_number))
         judges = [ci.judge for ci in CheckIn.objects.filter(round_number=current_round_number)]
         try:
+            backup.backup_round("round_%s_before_judge_assignment" % current_round_number)
             assign_judges.add_judges(rounds, judges, panel_points)
         except Exception as e:
             return render_to_response('error.html',


### PR DESCRIPTION
Fixes the issue at Yale referenced here: https://github.com/jolynch/mit-tab/issues/123

Refreshing after assigning judges would re-assign judges which is bad